### PR TITLE
Update sectors section messaging for target clients

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,10 +392,11 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <p class="eyebrow mb-2">A quién ayudamos</p>
       <h2 class="h-font text-3xl lg:text-4xl font-semibold mb-10">Sectores</h2>
-      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Puertos y consignatarios</h3><p class="text-neutral-700">MARPOL Anexo V, coordinación en muelle y documentación para tasas.</p></div>
-        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Industria y logística</h3><p class="text-neutral-700">Contenerización, rutas y KPI de servicio con reporting mensual.</p></div>
-        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Ayuntamientos y obras</h3><p class="text-neutral-700">Campañas, obras y eventos con contenedores y retirada integral.</p></div>
+      <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Puertos y navieras</h3><p class="text-neutral-700">MARPOL Anexo V para buques y cruceros, coordinación en escala y certificados listos para capitán y consignatario.</p></div>
+        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Industrias agroalimentarias</h3><p class="text-neutral-700">Gestión de subproductos SANDACH, lodos y envases; retirada programada en campaña y trazabilidad 100%.</p></div>
+        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Administraciones públicas</h3><p class="text-neutral-700">Apoyo en licitaciones, puntos limpios móviles y eventos municipales con documentación CAE y reporting.</p></div>
+        <div class="card p-6"><h3 class="h-font font-semibold text-lg mb-2">Construcción y rehabilitación</h3><p class="text-neutral-700">Contenedores para RCD, gestión de residuos peligrosos de obra y retirada selectiva en plazos ajustados.</p></div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- update the sectors section to highlight ports and navieras, agroindustries, administrations, and construction clients
- expand the grid layout to accommodate the four targeted sector cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4eeb6381c83269bfa8477f3985645